### PR TITLE
Add support for filtering property shapes by group

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,11 +29,12 @@ class SHACLValidator {
    * Validates the provided data graph against the provided shapes graph
    *
    * @param {DatasetCore} data - Dataset containing the data to validate
+   * @param {string} group - optional SHACL PropertyGroup for filtering shapes
    * @return {ValidationReport} - Result of the validation
    */
-  validate (data) {
+  validate (data, group) {
     this.$data = clownface({ dataset: data, factory: this.factory })
-    this.validationEngine.validateAll(this.$data)
+    this.validationEngine.validateAll(this.$data, group)
     return this.validationEngine.getReport()
   }
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ class SHACLValidator {
 
     this.factory = options.factory || require('@rdfjs/dataset')
     this.ns = prepareNamespaces(this.factory)
+    this.group = options.group
     this.loadShapes(shapes)
     this.validationEngine = new ValidationEngine(this, options)
 
@@ -29,12 +30,11 @@ class SHACLValidator {
    * Validates the provided data graph against the provided shapes graph
    *
    * @param {DatasetCore} data - Dataset containing the data to validate
-   * @param {string} group - optional SHACL PropertyGroup for filtering shapes
    * @return {ValidationReport} - Result of the validation
    */
-  validate (data, group) {
+  validate (data) {
     this.$data = clownface({ dataset: data, factory: this.factory })
-    this.validationEngine.validateAll(this.$data, group)
+    this.validationEngine.validateAll(this.$data)
     return this.validationEngine.getReport()
   }
 

--- a/src/shapes-graph.js
+++ b/src/shapes-graph.js
@@ -215,11 +215,13 @@ class Shape {
     this.deactivated = this.shapeNodePointer.out(sh.deactivated).value === 'true'
     this.path = this.shapeNodePointer.out(sh.path).term
     this.group = this.shapeNodePointer.out(sh.group).term
-
-    if (this.context.group && this.path && this.group && this.group.value != this.context.group) {
+    
+    // If shape doesn't have any group or the group is different from this.context.group,
+    // deactivate it
+    if (this.context.group && this.path && ((this.group && this.group.value != this.context.group) || !this.group)) {
       this.deactivated = true;
     }
-    
+
     this._pathObject = undefined
     this.shapeNode = shapeNode
     this.constraints = []

--- a/src/shapes-graph.js
+++ b/src/shapes-graph.js
@@ -214,6 +214,7 @@ class Shape {
 
     this.deactivated = this.shapeNodePointer.out(sh.deactivated).value === 'true'
     this.path = this.shapeNodePointer.out(sh.path).term
+    this.group = this.shapeNodePointer.out(sh.group).term
     this._pathObject = undefined
     this.shapeNode = shapeNode
     this.constraints = []

--- a/src/shapes-graph.js
+++ b/src/shapes-graph.js
@@ -215,6 +215,11 @@ class Shape {
     this.deactivated = this.shapeNodePointer.out(sh.deactivated).value === 'true'
     this.path = this.shapeNodePointer.out(sh.path).term
     this.group = this.shapeNodePointer.out(sh.group).term
+
+    if (this.context.group && this.path && this.group && this.group.value != this.context.group) {
+      this.deactivated = true;
+    }
+    
     this._pathObject = undefined
     this.shapeNode = shapeNode
     this.constraints = []

--- a/src/validation-engine.js
+++ b/src/validation-engine.js
@@ -139,8 +139,9 @@ class ValidationEngine {
    * Validates the data graph against the shapes graph
    *
    * @param {Clownface} dataGraph
+   * @param {string} group (optional)
    */
-  validateAll (dataGraph) {
+  validateAll (dataGraph, group) {
     if (this.maxErrorsReached()) {
       return true
     }
@@ -153,7 +154,7 @@ class ValidationEngine {
       for (const shape of shapes) {
         const focusNodes = shape.getTargetNodes(dataGraph)
         for (const focusNode of focusNodes) {
-          if (this.validateNodeAgainstShape(focusNode, shape, dataGraph)) {
+          if (this.validateNodeAgainstShape(focusNode, shape, dataGraph, group)) {
             foundError = true
           }
         }
@@ -168,26 +169,26 @@ class ValidationEngine {
   /**
    * Returns true if any violation has been found
    */
-  validateNodeAgainstShape (focusNode, shape, dataGraph) {
+  validateNodeAgainstShape (focusNode, shape, dataGraph, group) {
     if (this.maxErrorsReached()) {
       return true
     }
 
-    if (shape.deactivated) {
+    if (shape.deactivated || (group && shape.group && shape.group.value !== group)) {
       return false
     }
 
     const valueNodes = shape.getValueNodes(focusNode, dataGraph)
     let errorFound = false
     for (const constraint of shape.constraints) {
-      if (this.validateNodeAgainstConstraint(focusNode, valueNodes, constraint, dataGraph)) {
+      if (this.validateNodeAgainstConstraint(focusNode, valueNodes, constraint, dataGraph, group)) {
         errorFound = true
       }
     }
     return errorFound
   }
 
-  validateNodeAgainstConstraint (focusNode, valueNodes, constraint, dataGraph) {
+  validateNodeAgainstConstraint (focusNode, valueNodes, constraint, dataGraph, group) {
     const { sh } = this.context.ns
 
     if (this.maxErrorsReached()) {
@@ -197,7 +198,7 @@ class ValidationEngine {
     if (sh.PropertyConstraintComponent.equals(constraint.component.node)) {
       let errorFound = false
       for (const valueNode of valueNodes) {
-        if (this.validateNodeAgainstShape(valueNode, this.context.shapesGraph.getShape(constraint.paramValue), dataGraph)) {
+        if (this.validateNodeAgainstShape(valueNode, this.context.shapesGraph.getShape(constraint.paramValue), dataGraph, group)) {
           errorFound = true
         }
       }

--- a/src/validation-engine.js
+++ b/src/validation-engine.js
@@ -139,9 +139,8 @@ class ValidationEngine {
    * Validates the data graph against the shapes graph
    *
    * @param {Clownface} dataGraph
-   * @param {string} group (optional)
    */
-  validateAll (dataGraph, group) {
+  validateAll (dataGraph) {
     if (this.maxErrorsReached()) {
       return true
     }
@@ -154,7 +153,7 @@ class ValidationEngine {
       for (const shape of shapes) {
         const focusNodes = shape.getTargetNodes(dataGraph)
         for (const focusNode of focusNodes) {
-          if (this.validateNodeAgainstShape(focusNode, shape, dataGraph, group)) {
+          if (this.validateNodeAgainstShape(focusNode, shape, dataGraph)) {
             foundError = true
           }
         }
@@ -169,26 +168,26 @@ class ValidationEngine {
   /**
    * Returns true if any violation has been found
    */
-  validateNodeAgainstShape (focusNode, shape, dataGraph, group) {
+  validateNodeAgainstShape (focusNode, shape, dataGraph) {
     if (this.maxErrorsReached()) {
       return true
     }
 
-    if (shape.deactivated || (group && shape.group && shape.group.value !== group)) {
+    if (shape.deactivated) {
       return false
     }
 
     const valueNodes = shape.getValueNodes(focusNode, dataGraph)
     let errorFound = false
     for (const constraint of shape.constraints) {
-      if (this.validateNodeAgainstConstraint(focusNode, valueNodes, constraint, dataGraph, group)) {
+      if (this.validateNodeAgainstConstraint(focusNode, valueNodes, constraint, dataGraph)) {
         errorFound = true
       }
     }
     return errorFound
   }
 
-  validateNodeAgainstConstraint (focusNode, valueNodes, constraint, dataGraph, group) {
+  validateNodeAgainstConstraint (focusNode, valueNodes, constraint, dataGraph) {
     const { sh } = this.context.ns
 
     if (this.maxErrorsReached()) {
@@ -198,7 +197,7 @@ class ValidationEngine {
     if (sh.PropertyConstraintComponent.equals(constraint.component.node)) {
       let errorFound = false
       for (const valueNode of valueNodes) {
-        if (this.validateNodeAgainstShape(valueNode, this.context.shapesGraph.getShape(constraint.paramValue), dataGraph, group)) {
+        if (this.validateNodeAgainstShape(valueNode, this.context.shapesGraph.getShape(constraint.paramValue), dataGraph)) {
           errorFound = true
         }
       }

--- a/test/configuration_tests.js
+++ b/test/configuration_tests.js
@@ -21,3 +21,20 @@ describe('configuration', () => {
     assert.strictEqual(report2.results.length, 1)
   })
 })
+
+describe('configuration', () => {
+  it('only validates against property shapes with given group', async () => {
+    const dataFile = path.join(__dirname, '/data/data-shapes/core/misc/group.ttl')
+    const data = await loadDataset(dataFile)
+    const shapes = data
+
+    const validator1 = new SHACLValidator(shapes)
+    const report1 = validator1.validate(data)
+    assert.strictEqual(report1.conforms, false)
+    assert.strictEqual(report1.results.length, 2)
+
+    const validator2 = new SHACLValidator(shapes, { group: "http://datashapes.org/sh/tests/core/misc/group.test#SomeGroup" })
+    const report2 = validator2.validate(data)
+    assert.strictEqual(report2.conforms, true)
+  })
+})

--- a/test/data/data-shapes/core/misc/group.ttl
+++ b/test/data/data-shapes/core/misc/group.ttl
@@ -1,0 +1,35 @@
+@prefix ex: <http://datashapes.org/sh/tests/core/misc/group.test#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ex:Instance
+  rdf:type ex:Test ;
+  ex:path1 "path1" ;
+.
+
+ex:TestShape
+  rdf:type sh:NodeShape ;
+  sh:targetClass ex:Test ;
+  sh:property [
+    sh:path ex:path1 ;
+    sh:minCount 1 ;
+    sh:group ex:SomeGroup ;
+  ] ;
+  sh:property [
+    sh:path ex:path2 ;
+    sh:minCount 1 ;
+    sh:group ex:SomeOtherGroup ;
+  ] ;
+  sh:property [
+    sh:path ex:path3 ;
+    sh:minCount 1 ;
+  ]
+.
+
+ex:SomeGroup
+	a sh:PropertyGroup ;
+.
+
+ex:SomeOtherGroup
+	a sh:PropertyGroup ;
+.


### PR DESCRIPTION
ref: https://github.com/regen-network/regen-registry/issues/455

If `group` is provided as part of the `SHACLValidator` options, it's used to deactivate property shapes without `sh:group` or with `sh:group` different from the given group.